### PR TITLE
Fixes double image save in Cordova

### DIFF
--- a/Canvas2ImagePlugin.js
+++ b/Canvas2ImagePlugin.js
@@ -26,8 +26,7 @@ Canvas2ImagePlugin.prototype.saveImageDataToLibrary = function(successCallback, 
 	var imageData = canvas.toDataURL().replace(/data:image\/png;base64,/,'');
 	if (typeof PhoneGap !== "undefined") {
 		PhoneGap.exec(successCallback, failureCallback, "Canvas2ImagePlugin","saveImageDataToLibrary",[imageData]);
-	}
-	if (typeof Cordova !== "undefined") {
+	} else if (typeof Cordova !== "undefined") {
 		Cordova.exec(successCallback, failureCallback, "Canvas2ImagePlugin","saveImageDataToLibrary",[imageData]);
 	}
 };


### PR DESCRIPTION
In Cordova-PhoneGap 1.8.0 both PhoneGap and Cordova are defined therefore the image gets saved to the library twice. A simple elseif solves this.
