### PR TITLE
Changed the toSuccessCallbackString to toErrorCallbackString

### DIFF
--- a/Canvas2ImagePlugin.m
+++ b/Canvas2ImagePlugin.m
@@ -38,7 +38,7 @@
         // Show error message...
         NSLog(@"ERROR: %@",error);
 		CDVPluginResult* result = [CDVPluginResult resultWithStatus: CDVCommandStatus_ERROR messageAsString:error.description];
-		[self.webView stringByEvaluatingJavaScriptFromString:[result toSuccessCallbackString: self.callbackId]];
+		[self.webView stringByEvaluatingJavaScriptFromString:[result toErrorCallbackString: self.callbackId]];
     }
     else  // No errors
     {


### PR DESCRIPTION
Changed the toSuccessCallbackString to toErrorCallbackString to solve the problem described as in issue #10

Tested with Cordova 2.6.0 and iOS 6.1.2
