### PR TITLE
Allow a base64 encoded image string to be saved without canvas

### DIFF
--- a/www/Canvas2ImagePlugin.js
+++ b/www/Canvas2ImagePlugin.js
@@ -8,8 +8,7 @@
 //
 
   module.exports = {
-    
-    saveImageDataToLibrary:function(successCallback, failureCallback, canvasId) {
+    saveBase64ToLibrary:function(successCallback, failureCallback, imageData) {
         // successCallback required
         if (typeof successCallback != "function") {
             console.log("Canvas2ImagePlugin Error: successCallback is not a function");
@@ -18,10 +17,14 @@
             console.log("Canvas2ImagePlugin Error: failureCallback is not a function");
         }
         else {
-            var canvas = (typeof canvasId === "string") ? document.getElementById(canvasId) : canvasId;
-            var imageData = canvas.toDataURL().replace(/data:image\/png;base64,/,'');
             return cordova.exec(successCallback, failureCallback, "Canvas2ImagePlugin","saveImageDataToLibrary",[imageData]);
         }
+    },
+
+    saveImageDataToLibrary:function(successCallback, failureCallback, canvasId) {
+        var canvas = (typeof canvasId === "string") ? document.getElementById(canvasId) : canvasId;
+        var imageData = canvas.toDataURL().replace(/data:image\/png;base64,/,'');
+        return this.saveBase64ToLibrary(successCallback, failureCallback, imageData);
     }
   };
   


### PR DESCRIPTION
Not sure if this pull request will be useful for other users, but I needed the ability to save a base64 encoded image to the device without using a canvas.

This solution may not be the best as the successCallback is called after the base64 encoded string is fetched from the canvas, but I imagine this wouldn't happen in the majority of use cases.
