### PR TITLE
Create Pictures directory if it doesn't exist

### DIFF
--- a/src/android/Canvas2ImagePlugin.java
+++ b/src/android/Canvas2ImagePlugin.java
@@ -91,6 +91,10 @@ public class Canvas2ImagePlugin extends CordovaPlugin {
 			if (check >= 1) {
 				folder = Environment
 					.getExternalStoragePublicDirectory(Environment.DIRECTORY_PICTURES);
+				
+				if(!folder.exists()) {
+					folder.mkdirs();
+				}
 			} else {
 				folder = Environment.getExternalStorageDirectory();
 			}


### PR DESCRIPTION
The path returned by Environment.DIRECTORY_PICTURES didn't exist on a Sony Xperia test device.
