### PR TITLE
Add saveDataStringAsImageDataToLibrary api, input datastring as parameter.

### DIFF
--- a/www/Canvas2ImagePlugin.js
+++ b/www/Canvas2ImagePlugin.js
@@ -1,3 +1,5 @@
+cordova.define("org.devgeeks.Canvas2ImagePlugin.Canvas2ImagePlugin", function(require, exports, module) {
+
 //
 //  Canvas2ImagePlugin.js
 //  Canvas2ImagePlugin PhoneGap/Cordova plugin
@@ -33,17 +35,20 @@ module.exports = (function() {
         }
     }
 
-    function saveDataStringAsImageDataToLibrary(successCallback, failureCallback, imageData) {        
+    function saveDataStringAsImageDataToLibrary(successCallback, failureCallback, imageData) {
         if (validateCallBacks(successCallback, failureCallback)) {
             return cordova.exec(successCallback, failureCallback,
-                        "Canvas2ImagePlugin","saveImageDataToLibrary",[imageData]);
+                "Canvas2ImagePlugin","saveImageDataToLibrary",[imageData]);
         }
     }
 
-    return {    
+    return {
         saveImageDataToLibrary: saveImageDataToLibrary,
         saveDataStringAsImageDataToLibrary: saveDataStringAsImageDataToLibrary
     }
-    
-})();
-  
+
+})()
+
+});
+
+


### PR DESCRIPTION
Since canvas on mobile safari has limitation of width and height, 
FYI: http://stackoverflow.com/questions/6081483/maximum-size-of-a-canvas-element
We can not always using canvas to generate dataURL.

So we extends your helpful plugin with one extra api to have string as data to store into Library.

And then we can use XHR to grab a image as blob and then using FileReader#readAsDataURL to read out DataURL.
Then save it into Library.

It works for our project, hopefully can make this Plugin more helpful for others.
