### PR TITLE
Added image url for IOS success callback

### DIFF
--- a/src/ios/Canvas2ImagePlugin.h
+++ b/src/ios/Canvas2ImagePlugin.h
@@ -9,6 +9,7 @@
 
 
 #import <Cordova/CDVPlugin.h>
+#import <AssetsLibrary/ALAssetsLibrary.h>
 
 @interface Canvas2ImagePlugin : CDVPlugin
 {


### PR DESCRIPTION
Replaced the use of UIImageWriteToSavedPhotosAlbum with the function
writeImageToSavedPhotosAlbum from the library ALAssetsLibrary
The aim of this change is to be able to return the image URL to the
success callback