### PR TITLE
add images wrapper folder

### DIFF
--- a/src/android/Canvas2ImagePlugin.java
+++ b/src/android/Canvas2ImagePlugin.java
@@ -99,6 +99,12 @@ public class Canvas2ImagePlugin extends CordovaPlugin {
 				folder = Environment.getExternalStorageDirectory();
 			}
 			
+			folder = new File(folder, "cordova_app");
+
+			if (!folder.exists()) {
+				folder.mkdirs();
+			}
+
 			File imageFile = new File(folder, "c2i_" + date.toString() + ".png");
 
 			FileOutputStream out = new FileOutputStream(imageFile);


### PR DESCRIPTION
- I added a wrapper folder in the `Pictures` folder for android for the ease of organizing files. It was a mess when I tried to retrieved hundreds of images mixed other applications and I believed some people might experience it.

- Apparently, it was hard-coded as `cordova_app`. It is possible to get the `Application Name`, however, I am not that experience with android.